### PR TITLE
Experimental: QMIX implementation + session reward tuning

### DIFF
--- a/config/base/env.yml
+++ b/config/base/env.yml
@@ -9,15 +9,15 @@ action_directions:
   description: "Movement directions: right, down, left, up, STAY (3bede13 uses 5-action space)"
 
 reward_goal:
-  value: 10.0
-  description: "Reach-target reward (3bede13 = +10)"
+  value: 50.0
+  description: "Reach-target reward. Raised from 10 to 50 to dominate comm reward accumulation (omega=1 × 0.5/step × many steps)."
 
 reward_closer:
   value: 1.0
   description: "Reward when getting closer to target (3bede13 = +1; stacks on step so net 0 per closer step)"
 
 reward_farther:
-  value: 0.0
+  value: -1.0
   description: "Reward when moving away (3bede13 does NOT extra-penalize farther beyond step)"
 
 reward_same:
@@ -33,8 +33,8 @@ reward_step:
   description: "Per-step time penalty (applied to all active agents)"
 
 omega:
-  value: 0.0
-  description: "Communication reward weight. Set to 0.0 for navigation-only training (3bede13 did not mix BER into reward)."
+  value: 1
+  description: "Communication reward weight."
 
 ber_reward_better:
   value: 0.5

--- a/config/base/map.yml
+++ b/config/base/map.yml
@@ -1,16 +1,16 @@
 description: "Map size and forbidden-square generation (ported from commit 3bede13)"
 
 map_size:
-  value: [48, 24]
-  description: "Grid size (rows, cols). 3bede13 uses 48x24 (physical 19.2m x 9.6m at grid=0.4m)."
+  value: [120, 60]
+  description: "Grid size (rows, cols). Paper-aligned: physical 48m x 24m at grid=0.4m."
 
 antenna_position:
-  value: [24, 12]
-  description: "Antenna (x, y) grid coord, center of map in 3bede13"
+  value: [60, 30]
+  description: "Antenna (x, y) grid coord, center of 120x60 map (physical 24m, 12m)."
 
 number_of_robots:
-  value: 8
-  description: "Number of robots/agents (3bede13 trained MADQN with 8 agents)"
+  value: 4
+  description: "Number of robots/agents. Currently set for QMIX scan."
 
 num_forbidden_squares:
   value: 5

--- a/main.py
+++ b/main.py
@@ -21,13 +21,13 @@ import torch
 
 from env.env import MultiRobotEnv
 from config.yml_config import get_env_config, get_rl_config
-from rl_algorithms import DQN, MADQN, train, test, plot_training
+from rl_algorithms import DQN, MADQN, QMIX, train, test, plot_training
 from utils.logger_handler import get_logger
 
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Multi-Robot DRL Navigation (DQN / MADQN)")
-    p.add_argument("--model", choices=["dqn", "madqn"], default="madqn", help="algorithm")
+    p.add_argument("--model", choices=["dqn", "madqn", "qmix"], default="madqn", help="algorithm")
     p.add_argument("--mode", choices=["train", "test"], default="train", help="mode")
 
     # 训练超参（命令行覆盖 rl.yml）
@@ -80,6 +80,8 @@ def _build_model(algo: str, env, cfg: dict, device: torch.device, agent_id: int 
     )
     if algo == "dqn":
         return DQN(env, agent_id=agent_id, **common)
+    if algo == "qmix":
+        return QMIX(env, **common)
     return MADQN(env, **common)
 
 

--- a/rl_algorithms/__init__.py
+++ b/rl_algorithms/__init__.py
@@ -1,7 +1,7 @@
 """强化学习模块：扁平化导出，仅暴露接口。"""
-from rl_algorithms.algorithms import DQN, MADQN
+from rl_algorithms.algorithms import DQN, MADQN, QMIX
 from rl_algorithms.trainer import train
 from rl_algorithms.tester import test
 from rl_algorithms.plot import plot_training
 
-__all__ = ["DQN", "MADQN", "train", "test", "plot_training"]
+__all__ = ["DQN", "MADQN", "QMIX", "train", "test", "plot_training"]

--- a/rl_algorithms/algorithms.py
+++ b/rl_algorithms/algorithms.py
@@ -1,8 +1,9 @@
 """
-DQN 与 MADQN 算法：统一 take_action / update / save / load 接口。
+DQN / MADQN / QMIX 算法：统一 take_action / update / save / load 接口。
 
 DQN  : 单 agent 学习，指定 agent_id；其他 agent 训练/测试时走随机策略（在 trainer 内拼接）。
 MADQN: Independent DQN，每个 agent 独立 Q 网络、目标网络、回放缓冲。
+QMIX : N 个 Qnet + 单调 mixer，联合 TD target 训练；执行时分布式（各用自己的 Q_i）。
 """
 import os
 import numpy as np
@@ -11,7 +12,8 @@ import torch.nn as nn
 import torch.optim as optim
 
 from rl_algorithms.qnet import Qnet
-from rl_algorithms.replay import ReplayBuffer
+from rl_algorithms.replay import ReplayBuffer, JointReplayBuffer
+from rl_algorithms.mixer import Mixer
 
 
 def _build_qnet(env, hidden_dim: int) -> Qnet:
@@ -228,4 +230,203 @@ class MADQN:
             self.q_nets[i].load_state_dict(ckpt[f"qnet_{i}"])
             self.target_q_nets[i].load_state_dict(ckpt.get(f"target_qnet_{i}", ckpt[f"qnet_{i}"]))
             self.optimizers[i].load_state_dict(ckpt[f"optimizer_{i}"])
+        self.epsilon = ckpt.get("epsilon", self.epsilon)
+
+
+class QMIX:
+    """
+    QMIX：N 个 Qnet + 单调 Mixer，联合训练。
+
+    - 执行（take_action）：每 agent 用自己的 Q_i argmax（与 MADQN 一致，包含冲突规避）。
+    - 训练（update）：从 JointReplayBuffer 采 (B, N) 形 batch，
+      计算 Q_tot = mixer([Q_i(s_i, a_i)]_i, s_global)，联合 MSE(Q_tot, y) 反传，
+      梯度通过 mixer 自动分配到每个 Q_i（隐式 credit assignment）。
+    """
+
+    def __init__(self, env,
+                 lr: float = 1e-4, gamma: float = 0.9,
+                 epsilon: float = 0.5, epsilon_min: float = 0.01, epsilon_decay: float = 0.99,
+                 hidden_dim: int = 128, update_freq: int = 100,
+                 replay_buffer_size: int = 50000,
+                 mixer_embed_dim: int = 32,
+                 device: torch.device = torch.device("cpu")):
+        self.env = env
+        self.num_agents = env.num_agents
+        self.n_actions = env.n_actions
+        self.n_powers = env.n_powers
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.epsilon_min = epsilon_min
+        self.epsilon_decay = epsilon_decay
+        self.device = device
+        self.update_freq = update_freq
+
+        # per-agent Q 网络 + target（放 ModuleList 方便统一取 parameters）
+        self.q_nets = nn.ModuleList([_build_qnet(env, hidden_dim) for _ in range(self.num_agents)]).to(device)
+        self.target_q_nets = nn.ModuleList([_build_qnet(env, hidden_dim) for _ in range(self.num_agents)]).to(device)
+        for i in range(self.num_agents):
+            self.target_q_nets[i].load_state_dict(self.q_nets[i].state_dict())
+            self.target_q_nets[i].eval()
+
+        # 全局状态维度：每 agent (row_norm, col_norm, target_row_norm, target_col_norm) = 4N
+        self._state_dim = 4 * self.num_agents
+        self.mixer = Mixer(self.num_agents, self._state_dim, embed_dim=mixer_embed_dim).to(device)
+        self.target_mixer = Mixer(self.num_agents, self._state_dim, embed_dim=mixer_embed_dim).to(device)
+        self.target_mixer.load_state_dict(self.mixer.state_dict())
+        self.target_mixer.eval()
+
+        # 单一 optimizer 覆盖所有 Q 和 mixer 参数
+        params = list(self.q_nets.parameters()) + list(self.mixer.parameters())
+        self.optimizer = optim.Adam(params, lr=lr)
+        self.loss_fn = nn.MSELoss()
+        self.buffer = JointReplayBuffer(replay_buffer_size)
+        self.batch_size = 128
+
+    # ------------------------------------------------------------------ 工具
+    def _decode_dir(self, action: int) -> int:
+        return action // self.n_powers
+
+    def _states_to_global(self, states_batch: np.ndarray) -> torch.Tensor:
+        """
+        states_batch: (B, N) int64，每项是 pos_to_index。
+        return: (B, 4N) float32 —— 每 agent 的归一化 (row, col, target_row, target_col)。
+        """
+        B, N = states_batch.shape
+        rows, cols = self.env.rows, self.env.cols
+        out = np.zeros((B, 4 * N), dtype=np.float32)
+        for i in range(N):
+            state_i = states_batch[:, i]
+            out[:, 4 * i + 0] = (state_i // cols).astype(np.float32) / max(rows, 1)
+            out[:, 4 * i + 1] = (state_i % cols).astype(np.float32) / max(cols, 1)
+            tgt_r, tgt_c = self.env.target_states[i]
+            out[:, 4 * i + 2] = float(tgt_r) / max(rows, 1)
+            out[:, 4 * i + 3] = float(tgt_c) / max(cols, 1)
+        return torch.tensor(out, device=self.device)
+
+    # ------------------------------------------------------------------ 动作选择
+    def take_action(self, states, training: bool = True):
+        """
+        Decentralized epsilon-greedy + 与 MADQN 一致的冲突规避（同格占用 / 禁区回退）。
+        """
+        actions = []
+        occupied = set()
+        directions = self.env.directions
+        for i in range(self.num_agents):
+            if self.env.done_flags is not None and self.env.done_flags[i]:
+                actions.append(0)
+                continue
+            target_idx = self.env.pos_to_index(*self.env.target_states[i])
+            s = torch.tensor([states[i]], dtype=torch.long, device=self.device)
+            t = torch.tensor([target_idx], dtype=torch.long, device=self.device)
+            with torch.no_grad():
+                q = self.q_nets[i](s, t)
+            if training and np.random.random() < self.epsilon:
+                action = int(np.random.randint(self.n_actions))
+            else:
+                action = int(q.argmax(dim=1).item())
+
+            dr, dc = directions[self._decode_dir(action)]
+            cur_r, cur_c = self.env.positions[i]
+            new_r = int(cur_r + dr)
+            new_c = int(cur_c + dc)
+            if (new_r, new_c) in occupied or (new_r, new_c) in self.env.forbidden_set:
+                sorted_actions = q.argsort(dim=1, descending=True).squeeze().tolist()
+                if isinstance(sorted_actions, int):
+                    sorted_actions = [sorted_actions]
+                for alt in sorted_actions:
+                    dr2, dc2 = directions[self._decode_dir(alt)]
+                    nr2 = int(cur_r + dr2)
+                    nc2 = int(cur_c + dc2)
+                    if (nr2, nc2) not in occupied and (nr2, nc2) not in self.env.forbidden_set:
+                        action, new_r, new_c = alt, nr2, nc2
+                        break
+            occupied.add((new_r, new_c))
+            actions.append(action)
+        return actions
+
+    # ------------------------------------------------------------------ 联合更新
+    def update(self, batch) -> float:
+        """
+        batch: tuple of (states, actions, rewards, next_states, dones)，均为 (B, N) array。
+        联合 TD 更新（一次反传，梯度经 mixer 流到所有 Q_i 与 mixer 自身）。
+        """
+        states, actions, rewards, next_states, dones = batch
+        B, N = states.shape
+
+        s = torch.tensor(states, dtype=torch.long, device=self.device)
+        ns = torch.tensor(next_states, dtype=torch.long, device=self.device)
+        a = torch.tensor(actions, dtype=torch.long, device=self.device)
+        r = torch.tensor(rewards, dtype=torch.float32, device=self.device)
+        d = torch.tensor(dones, dtype=torch.float32, device=self.device)
+
+        # 全局状态
+        s_global = self._states_to_global(states)
+        ns_global = self._states_to_global(next_states)
+
+        # 1) 当前 Q_i(s_i, a_i)
+        q_list = []
+        for i in range(N):
+            target_idx = self.env.pos_to_index(*self.env.target_states[i])
+            t_i = torch.full((B,), target_idx, dtype=torch.long, device=self.device)
+            q_i = self.q_nets[i](s[:, i], t_i).gather(1, a[:, i:i + 1]).squeeze(1)  # (B,)
+            q_list.append(q_i)
+        q_stack = torch.stack(q_list, dim=1)                     # (B, N)
+        q_tot = self.mixer(q_stack, s_global)                     # (B,)
+
+        # 2) Target Q_tot：target Q_i^-(s'_i, argmax_a Q_i^-), 已 done 的 agent 贡献置 0
+        with torch.no_grad():
+            q_next_list = []
+            for i in range(N):
+                target_idx = self.env.pos_to_index(*self.env.target_states[i])
+                t_i = torch.full((B,), target_idx, dtype=torch.long, device=self.device)
+                q_next_max = self.target_q_nets[i](ns[:, i], t_i).max(dim=1)[0]  # (B,)
+                q_next_max = q_next_max * (1.0 - d[:, i])
+                q_next_list.append(q_next_max)
+            q_next_stack = torch.stack(q_next_list, dim=1)                       # (B, N)
+            q_tot_target = self.target_mixer(q_next_stack, ns_global)            # (B,)
+
+            r_joint = r.sum(dim=1)                                                # (B,)
+            d_all = d.prod(dim=1)  # episode-level done：所有 agent done 时为 1
+            y = r_joint + self.gamma * q_tot_target * (1.0 - d_all)
+
+        loss = self.loss_fn(q_tot, y)
+        self.optimizer.zero_grad()
+        loss.backward()
+        # 梯度裁剪，防 Q_tot 幅度大时爆梯度
+        params = list(self.q_nets.parameters()) + list(self.mixer.parameters())
+        torch.nn.utils.clip_grad_norm_(params, max_norm=10.0)
+        self.optimizer.step()
+        return float(loss.item())
+
+    # ------------------------------------------------------------------ target sync
+    def update_target_qnet(self):
+        """同步所有 agent Q_i 与 mixer 的 target 副本。"""
+        for i in range(self.num_agents):
+            self.target_q_nets[i].load_state_dict(self.q_nets[i].state_dict())
+        self.target_mixer.load_state_dict(self.mixer.state_dict())
+
+    # ------------------------------------------------------------------ 保存/加载
+    def save(self, path: str):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        ckpt = {
+            "epsilon": self.epsilon,
+            "mixer": self.mixer.state_dict(),
+            "target_mixer": self.target_mixer.state_dict(),
+            "optimizer": self.optimizer.state_dict(),
+        }
+        for i in range(self.num_agents):
+            ckpt[f"qnet_{i}"] = self.q_nets[i].state_dict()
+            ckpt[f"target_qnet_{i}"] = self.target_q_nets[i].state_dict()
+        torch.save(ckpt, path)
+
+    def load(self, path: str):
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Model file not found: {path}")
+        ckpt = torch.load(path, map_location=self.device, weights_only=False)
+        for i in range(self.num_agents):
+            self.q_nets[i].load_state_dict(ckpt[f"qnet_{i}"])
+            self.target_q_nets[i].load_state_dict(ckpt.get(f"target_qnet_{i}", ckpt[f"qnet_{i}"]))
+        self.mixer.load_state_dict(ckpt["mixer"])
+        self.target_mixer.load_state_dict(ckpt.get("target_mixer", ckpt["mixer"]))
+        self.optimizer.load_state_dict(ckpt["optimizer"])
         self.epsilon = ckpt.get("epsilon", self.epsilon)

--- a/rl_algorithms/mixer.py
+++ b/rl_algorithms/mixer.py
@@ -1,0 +1,67 @@
+"""
+QMIX 单调混合网络（mixer）。
+
+论文：Rashid et al. 2018, "QMIX: Monotonic Value Function Factorisation for Deep
+Multi-Agent Reinforcement Learning"。
+
+给定 N 个 agent 的 Q_i(s_i, a_i) 以及全局状态 s，mixer 输出联合 Q_tot：
+
+    Q_tot = w2 · ELU(W1 @ [Q_1, ..., Q_N] + b1) + b2
+
+其中 W1, w2 由 hypernetwork(s) 生成，并对生成结果 abs(·) 以保证 **单调性**（
+∂Q_tot/∂Q_i ≥ 0）。单调性保证 argmax_{a_i} Q_i 联合起来等价于 argmax Q_tot，
+因此训练时中心化、执行时分布式。
+
+b2 来自两层 MLP hypernetwork，不做非负约束（相当于 state-dependent value bias）。
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Mixer(nn.Module):
+    """QMIX mixer：Q_tot = f(Q_vec; state) 的单调 MLP。"""
+
+    def __init__(self, num_agents: int, state_dim: int, embed_dim: int = 32):
+        """
+        :param num_agents: agent 数量 N
+        :param state_dim:  全局状态维度（一般是 N 个 agent 位置/目标的拼接）
+        :param embed_dim:  mixer 隐层宽度
+        """
+        super().__init__()
+        self.num_agents = num_agents
+        self.state_dim = state_dim
+        self.embed_dim = embed_dim
+
+        # 第一层：W1 ∈ R^{N × E}
+        self.hyper_w1 = nn.Linear(state_dim, num_agents * embed_dim)
+        self.hyper_b1 = nn.Linear(state_dim, embed_dim)
+        # 第二层：W2 ∈ R^{E × 1}
+        self.hyper_w2 = nn.Linear(state_dim, embed_dim)
+        # 终偏置 b2：两层 MLP 输出标量（不做单调约束）
+        self.hyper_b2 = nn.Sequential(
+            nn.Linear(state_dim, embed_dim),
+            nn.ReLU(),
+            nn.Linear(embed_dim, 1),
+        )
+
+    def forward(self, agent_qs: torch.Tensor, states: torch.Tensor) -> torch.Tensor:
+        """
+        :param agent_qs: (B, N) 每个 agent 的 Q_i(s_i, a_i)
+        :param states:   (B, state_dim) 全局状态
+        :return: (B,) 联合 Q_tot
+        """
+        B = agent_qs.shape[0]
+        # 第一层权重与偏置：单调性靠 abs 保证
+        w1 = torch.abs(self.hyper_w1(states)).view(B, self.num_agents, self.embed_dim)
+        b1 = self.hyper_b1(states).view(B, 1, self.embed_dim)
+        # (B, 1, N) @ (B, N, E) -> (B, 1, E)
+        h = torch.bmm(agent_qs.view(B, 1, self.num_agents), w1) + b1
+        h = F.elu(h)
+
+        # 第二层
+        w2 = torch.abs(self.hyper_w2(states)).view(B, self.embed_dim, 1)
+        b2 = self.hyper_b2(states).view(B, 1, 1)
+        # (B, 1, E) @ (B, E, 1) -> (B, 1, 1)
+        q_tot = torch.bmm(h, w2) + b2
+        return q_tot.view(B)

--- a/rl_algorithms/replay.py
+++ b/rl_algorithms/replay.py
@@ -24,3 +24,37 @@ class ReplayBuffer:
 
     def __len__(self):
         return len(self.buffer)
+
+
+class JointReplayBuffer:
+    """
+    N-agent 联合 transition 存储：每条 = (states[N], actions[N], rewards[N], next_states[N], dones[N])。
+    采样返回 (B, N) 形状的 batch，供 QMIX 联合 TD 更新使用。
+    """
+
+    def __init__(self, capacity: int = 50000):
+        self.buffer = collections.deque(maxlen=capacity)
+
+    def add(self, states, actions, rewards, next_states, dones):
+        """输入是长度 N 的 list/array（每项对应一个 agent）。"""
+        self.buffer.append((
+            np.asarray(states, dtype=np.int64),
+            np.asarray(actions, dtype=np.int64),
+            np.asarray(rewards, dtype=np.float32),
+            np.asarray(next_states, dtype=np.int64),
+            np.asarray(dones, dtype=np.float32),
+        ))
+
+    def sample(self, batch_size: int):
+        batch = random.sample(self.buffer, min(batch_size, len(self.buffer)))
+        states, actions, rewards, next_states, dones = zip(*batch)
+        return (
+            np.stack(states),        # (B, N) int
+            np.stack(actions),       # (B, N) int
+            np.stack(rewards),       # (B, N) float
+            np.stack(next_states),   # (B, N) int
+            np.stack(dones),         # (B, N) float
+        )
+
+    def __len__(self):
+        return len(self.buffer)

--- a/rl_algorithms/tester.py
+++ b/rl_algorithms/tester.py
@@ -8,11 +8,11 @@ import matplotlib
 matplotlib.rcParams["axes.unicode_minus"] = False
 import matplotlib.pyplot as plt
 
-from rl_algorithms.algorithms import MADQN
+from rl_algorithms.algorithms import MADQN, QMIX
 
 
 def _take_all_actions(env, model, states):
-    if isinstance(model, MADQN):
+    if isinstance(model, (MADQN, QMIX)):
         return model.take_action(states, training=False)
     actions = [int(np.random.randint(env.n_actions)) for _ in range(env.num_agents)]
     actions[model.agent_id] = model.take_action(states[model.agent_id], training=False)

--- a/rl_algorithms/trainer.py
+++ b/rl_algorithms/trainer.py
@@ -8,12 +8,12 @@
 import numpy as np
 from tqdm import tqdm
 
-from rl_algorithms.algorithms import DQN, MADQN
+from rl_algorithms.algorithms import DQN, MADQN, QMIX
 
 
 def _take_all_actions(env, model, states, training: bool):
     """按模型类型返回所有 agent 的动作列表。DQN 下非 agent_id 的 agent 走均匀随机。"""
-    if isinstance(model, MADQN):
+    if isinstance(model, (MADQN, QMIX)):
         return model.take_action(states, training=training)
     actions = [int(np.random.randint(env.n_actions)) for _ in range(env.num_agents)]
     actions[model.agent_id] = model.take_action(states[model.agent_id], training=training)
@@ -23,7 +23,12 @@ def _take_all_actions(env, model, states, training: bool):
 def _push_and_maybe_update(model, step_data, global_step: int, train_interval: int):
     """把 (s, a, r, ns, d) 写进 replay；每 train_interval 步采样一次进行梯度更新。"""
     states, actions, rewards, next_states, dones = step_data
-    if isinstance(model, MADQN):
+    if isinstance(model, QMIX):
+        # QMIX：单一联合 buffer，单次联合反传
+        model.buffer.add(states, actions, rewards, next_states, dones)
+        if global_step % train_interval == 0 and len(model.buffer) >= model.batch_size:
+            model.update(model.buffer.sample(model.batch_size))
+    elif isinstance(model, MADQN):
         for i in range(model.num_agents):
             model.buffers[i].add(states[i], actions[i], rewards[i], next_states[i], dones[i])
         if global_step % train_interval == 0:
@@ -39,7 +44,9 @@ def _push_and_maybe_update(model, step_data, global_step: int, train_interval: i
 
 def _sync_target(model, global_step: int):
     if global_step % model.update_freq == 0:
-        if isinstance(model, MADQN):
+        if isinstance(model, QMIX):
+            model.update_target_qnet()  # 一次同步所有 Q_i 与 mixer
+        elif isinstance(model, MADQN):
             for i in range(model.num_agents):
                 model.update_target_qnet(i)
         else:
@@ -63,7 +70,13 @@ def train(env, model,
     model.batch_size = batch_size
     num_agents = env.num_agents
     is_madqn = isinstance(model, MADQN)
-    algo_name = "MADQN" if is_madqn else "DQN"
+    is_qmix = isinstance(model, QMIX)
+    if is_qmix:
+        algo_name = "QMIX"
+    elif is_madqn:
+        algo_name = "MADQN"
+    else:
+        algo_name = "DQN"
 
     return_list = []
     step_return_list = []
@@ -82,10 +95,14 @@ def train(env, model,
     ep_counter = 0
 
     if logger:
+        if is_madqn:
+            lr_val = model.optimizers[0].param_groups[0]['lr']
+        else:
+            # DQN / QMIX 都只有一个 optimizer
+            lr_val = model.optimizer.param_groups[0]['lr']
         logger.info("%s training start: iters=%s episodes=%s ep_len=%s agents=%s lr=%.1e gamma=%.2f eps=%.2f bs=%s",
                     algo_name, num_iterations, num_episodes, episode_length, num_agents,
-                    (model.optimizers[0].param_groups[0]['lr'] if is_madqn else model.optimizer.param_groups[0]['lr']),
-                    model.gamma, model.epsilon, batch_size)
+                    lr_val, model.gamma, model.epsilon, batch_size)
 
     for it in range(1, num_iterations + 1):
         # 每轮外层迭代重置 epsilon，借助噪声跳出局部最优


### PR DESCRIPTION
- rl_algorithms/mixer.py (new): QMIX monotonic mixer with hypernet.
- rl_algorithms/algorithms.py: add QMIX class with joint TD update via mixer.
- rl_algorithms/replay.py: add JointReplayBuffer for N-agent joint transitions.
- rl_algorithms/trainer.py, tester.py, __init__.py: dispatch QMIX.
- main.py: --model qmix option.
- config/base/env.yml: reward_goal 10 -> 50, reward_farther 0 -> -1, omega 0 -> 1.
- config/base/map.yml: number_of_robots set to 4 (varied during agent scan).

Known issue: QMIX N=4 diverges under r_joint = sum(r_i) at current lr.
Fix TODO: normalize joint reward to r.mean(dim=1), or scale lr with N.